### PR TITLE
Fix for issue #75; fire selection event only on left mouse button click

### DIFF
--- a/src/main/java/org/mihalis/opal/roundedToolbar/RoundedToolbar.java
+++ b/src/main/java/org/mihalis/opal/roundedToolbar/RoundedToolbar.java
@@ -132,6 +132,9 @@ public class RoundedToolbar extends Canvas {
 		addListener(SWT.MouseUp, new Listener() {
 			@Override
 			public void handleEvent(final Event event) {
+				if (event.button != 1) {
+					return;
+				}
 				for (final RoundedToolItem item : items) {
 					if (item.getBounds().contains(event.x, event.y)) {
 						if (!multiSelection) {


### PR DESCRIPTION
Changing selection only on left mouse button click; allows context menu to be added to RoundedToolbar.